### PR TITLE
ci(pipeline.yml): #275 build semver versioned container image using cog-bump

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -106,7 +106,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args:  --severity-threshold=high
+          args: --severity-threshold=high
   sast-dockerfile-trivy-hadolint:
     runs-on: ubuntu-latest
     needs: build
@@ -134,6 +134,20 @@ jobs:
       - sast-code-snyk
       - sast-dockerfile-trivy-hadolint
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: fetch-tags
+        run: git fetch --tags origin
+        shell: bash
+      - id: bump-version
+        uses: armakuni/github-actions/bump-version@main
+      - name: check-bump-version-output
+        run: |
+          echo "version-was-bump: ${{ steps.bump-version.outputs.version-was-bump }}"
+          echo "previous-version: ${{ steps.bump-version.outputs.previous-version }}"
+          echo "current-version: ${{ steps.bump-version.outputs.current-version }}"
+        shell: bash
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -145,24 +159,25 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            abhisheksr01/companieshouse
+          images: abhisheksr01/companieshouse
+          context: git
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},prefix=v,value=${{ steps.bump-version.outputs.current-version }}
           labels: |
             "org.opencontainers.image.title": "abhisheksr01/companieshouse",
             "org.opencontainers.image.description": "Best practices and integrations available for Spring Boot based Microservice in a single repository with companieshouse API use case.",
             "org.opencontainers.image.url": "https://github.com/abhisheksr01/spring-boot-microservice-best-practices",
             "org.opencontainers.image.source": "https://github.com/abhisheksr01/spring-boot-microservice-best-practices",
-            "org.opencontainers.image.version": "0.1.0",
+            "org.opencontainers.image.version": ${{ steps.bump-version.outputs.current-version }},
             "org.opencontainers.image.created": "2020-01-10T00:30:00.000Z",
             "org.opencontainers.image.revision": ${{ github.sha }},
             "org.opencontainers.image.licenses": "MIT"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
-          tags: abhisheksr01/companieshouse:latest
+          push: ${{ github.event_name != 'pull_request' }} # Only push on main branch
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: true

--- a/cog.toml
+++ b/cog.toml
@@ -1,5 +1,5 @@
 from_latest_tag = true
-ignore_merge_commits = false
+ignore_merge_commits = true
 tag_prefix = "v" # This is important to enable latest tag check with you use v prefix
 #disable_changelog = false
 #disable_bump_commit = false


### PR DESCRIPTION
# Description

This PR does the following:
- Update cog.toml with ignore_merge_commits = true
- Use `armakuni/github-actions/bump-version@main` action for calculating new version and build images with it
- Only push images on main branch
- Use meta data for building the image